### PR TITLE
fix: ensure custom components have attributes passed through correctly

### DIFF
--- a/harden-react-markdown/src/index.test.tsx
+++ b/harden-react-markdown/src/index.test.tsx
@@ -551,9 +551,37 @@ block code
         </HardenedReactMarkdown>
       );
 
-      // Should use hardened component, not custom one
+      // Should use hardened component, not custom one, for blocked URLs
       expect(screen.queryByTestId("custom-link")).not.toBeInTheDocument();
       expect(screen.getByText("Link [blocked]")).toBeInTheDocument();
+    });
+
+    it("uses custom components with security enhancements for allowed URLs", () => {
+      const customComponents = {
+        a: ({ children, className, ...props }: any) => (
+          <a data-testid="custom-link" className={`custom-class ${className || ''}`} {...props}>
+            {children}
+          </a>
+        ),
+      };
+
+      render(
+        <HardenedReactMarkdown 
+          components={customComponents}
+          defaultOrigin="https://example.com"
+          allowedLinkPrefixes={["https://example.com/"]}
+        >
+          {"[Link](https://example.com/page)"}
+        </HardenedReactMarkdown>
+      );
+
+      // Should use custom component with security enhancements
+      const link = screen.getByTestId("custom-link");
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "https://example.com/page");
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+      expect(link).toHaveClass("custom-class");
     });
 
     it("accepts remarkPlugins and rehypePlugins", () => {

--- a/harden-react-markdown/src/index.tsx
+++ b/harden-react-markdown/src/index.tsx
@@ -117,9 +117,22 @@ export default function hardenReactMarkdown<
     };
 
     const hardenedComponents: Components = {
-      a: ({ href, children, ...props }) => {
+      a: ({ href, children, node, ...props }) => {
         const transformedUrl = transformUrl(href, allowedLinkPrefixes);
         if (transformedUrl !== null) {
+          // If user provided a custom 'a' component, use it with the transformed URL
+          if (userComponents?.a) {
+            return createElement(userComponents.a, {
+              href: transformedUrl,
+              children,
+              node,
+              target: "_blank",
+              rel: "noopener noreferrer",
+              ...props,
+            });
+          }
+          
+          // Otherwise use default anchor with security attributes
           return (
             <a
               href={transformedUrl}
@@ -137,9 +150,20 @@ export default function hardenReactMarkdown<
           </span>
         );
       },
-      img: ({ src, alt, ...props }) => {
+      img: ({ src, alt, node, ...props }) => {
         const transformedUrl = transformUrl(src, allowedImagePrefixes);
         if (transformedUrl !== null) {
+          // If user provided a custom 'img' component, use it with the transformed URL
+          if (userComponents?.img) {
+            return createElement(userComponents.img, {
+              src: transformedUrl,
+              alt,
+              node,
+              ...props,
+            });
+          }
+          
+          // Otherwise use default img
           return <img src={transformedUrl} alt={alt} {...props} />;
         }
         return (


### PR DESCRIPTION
This pull request enhances the flexibility and security of the `HardenedReactMarkdown` component by allowing user-provided custom components for links and images, while still enforcing security measures and URL whitelisting. The test suite has also been expanded to verify these new behaviors.

**Custom component support and security enforcement:**

* The `hardenReactMarkdown` function now supports user-provided custom components for `a` (links) and `img` (images). When a custom component is provided and the URL is allowed, the library will use the custom component, injecting security attributes (`target="_blank"`, `rel="noopener noreferrer"`) for links. If no custom component is provided, the default hardened component is used. [[1]](diffhunk://#diff-253605bc6bc33f7f4727a39d5e4cf884d48aa03555af4a45f2cc313666c86e24L120-R135) [[2]](diffhunk://#diff-253605bc6bc33f7f4727a39d5e4cf884d48aa03555af4a45f2cc313666c86e24L140-R166)

**Test coverage improvements:**

* Added a new test to ensure that custom components are used for allowed URLs and that security enhancements are applied to links.